### PR TITLE
Issue-10 Added setting for character sheet Skills section (resolves #10)

### DIFF
--- a/ModularFate.js
+++ b/ModularFate.js
@@ -9,11 +9,11 @@
  *      and licensed for our use under the Creative Commons Attribution 3.0 Unported license
  *      (http://creativecommons.org/licenses/by/3.0/).
  *
- *      This work is based on Fate Condensed (found at http://www.faterpg.com/), a product of Evil Hat Productions, LLC, 
- *      developed, authored, and edited by PK Sullivan, Ed Turner, Leonard Balsera, Fred Hicks, Richard Bellingham, Robert Hanz, Ryan Macklin, 
+ *      This work is based on Fate Condensed (found at http://www.faterpg.com/), a product of Evil Hat Productions, LLC,
+ *      developed, authored, and edited by PK Sullivan, Ed Turner, Leonard Balsera, Fred Hicks, Richard Bellingham, Robert Hanz, Ryan Macklin,
  *      and Sophie Lagacé, and licensed for our use under the Creative Commons Attribution 3.0 Unported license (http://creativecommons.org/licenses/by/3.0/).
  *
- * 
+ *
  * Note to self: New standardised hook signatures:
  * preCreate[documentName](document:Document, data:object, options:object, userId:string) {}
  * create[documentName](document:Document, options:object, userId: string) {}
@@ -46,7 +46,7 @@ Hooks.on("preCreateActor", async (actor, data, options, userId) => {
         if (game.user == game.users.find(e => e.isGM && e.active) || game.user.id === userId){
             if (actor?.data?.data?.details?.fatePoints?.refresh === ""){
                 let modified_data = await initialiseModularFateCharacter(actor);
-                data.data = modified_data.data;            
+                data.data = modified_data.data;
             }
         }
     }
@@ -62,15 +62,15 @@ async function initialiseModularFateCharacter (actor) {
 
     working_data.data.details.fatePoints.refresh = refresh;
     working_data.data.details.fatePoints.current = refresh;
-    
+
     let p_skills=working_data.data.skills;
-    
+
     //Check to see what skills the character has compared to the global skill list
         var skill_list = game.settings.get("ModularFate","skills");
         // This is the number of skills the character has currently.
         //We only need to add any skills if this is currently 0,
-        
-        
+
+
         let skills_to_add = [];
 
         for (let w in skill_list){
@@ -89,7 +89,7 @@ async function initialiseModularFateCharacter (actor) {
                 skill.rank=0;
                 p_skills[skill.name]=skill;
             })
-        }        
+        }
 
         let aspects = game.settings.get("ModularFate", "aspects");
         let player_aspects = duplicate(aspects);
@@ -98,7 +98,7 @@ async function initialiseModularFateCharacter (actor) {
         }
         //Now to store the aspect list to the character
         working_data.data.aspects = player_aspects;
-    
+
         //Step one, get the list of universal tracks.
         let world_tracks = duplicate(game.settings.get("ModularFate", "tracks"));
         let tracks_to_write = working_data.data.tracks;
@@ -129,7 +129,7 @@ async function initialiseModularFateCharacter (actor) {
                 track.aspect.as_name = false;
             }
 
-            //Initialise the box array for this track 
+            //Initialise the box array for this track
             if (track.boxes > 0) {
                 let box_values = [];
                 for (let i = 0; i < track.boxes; i++) {
@@ -140,7 +140,7 @@ async function initialiseModularFateCharacter (actor) {
         }
     working_data.data.tracks = tracks_to_write;
     let tracks = working_data.data.tracks;
-    
+
     let categories = game.settings.get("ModularFate", "track_categories");
     //GO through all the tracks, find the ones with boxes, check the number of boxes and linked skills and initialise as necessary.
     for (let t in tracks) {
@@ -403,9 +403,9 @@ Hooks.once('init', async function () {
         onChange: value => {
             if (value == true && game.user.isGM){
                 let text = ModularFateConstants.exportSettings();
- 
+
                 new Dialog({
-                    title: game.i18n.localize("ModularFate.ExportSettingsDialogTitle"), 
+                    title: game.i18n.localize("ModularFate.ExportSettingsDialogTitle"),
                     content: `<div style="background-color:white; color:black;"><textarea rows="20" style="font-family:Montserrat; width:382px; background-color:white; border:1px solid lightsteelblue; color:black;" id="export_settings">${text}</textarea></div>`,
                     buttons: {
                     },
@@ -440,7 +440,7 @@ Hooks.once('init', async function () {
         restricted:true,
         default:""
     })
-    
+
     game.settings.register("ModularFate", "gameNotes", {
         name: game.i18n.localize("ModularFate.GameNotes"),
         scope:"world",
@@ -475,7 +475,7 @@ Hooks.once('init', async function () {
         config:true,
         type:Number,
         restricted:true,
-        default:0 
+        default:0
     })
 
     game.settings.register("ModularFate","fuAspectLabelFont", {

--- a/lang/en.json
+++ b/lang/en.json
@@ -66,6 +66,10 @@
     "ModularFate.Biography":"Biography",
     "ModularFate.Description":"Description",
     "ModularFate.Skills":"Skills",
+    "ModularFate.SkillsLabelName": "Skills label",
+    "ModularFate.SkillsLabelHint": "The label used on the character sheet for the Skills section. If left empty, will default to 'Skills'",
+    "ModularFate.defaultSkillsLabel": "Skills",
+    "ModularFate.FateAcceleratedSkillsLabel": "Approaches",
     "ModularFate.Tracks":"Tracks",
     "ModularFate.clickHereToEditTrackNotes":"Click here to edit the track notes for",
     "ModularFate.Stunts":"Stunts",
@@ -475,7 +479,7 @@
             "attack":"Athletics is not meant as an attack skill.",
             "defend":"Athletics is a catchall skill to roll for defense in a physical conflict, against close quarters and ranged attacks. You can also use it to defend against characters trying to move past you, if you’re in a position to physically interfere with whoever’s making the attempt.",
             "pc":true
-            },    
+            },
         "Burglary":{
             "name":"Burglary","description":"The Burglary skill covers your character’s aptitude for stealing things and getting into places that are off-limits.\nIn genres that rely on the use of a lot of technology, this skill also includes a proficiency in the related tech, allowing the character to hack security systems, disable alarm systems, and whatnot.","overcome":"Burglary allows you to overcome any obstacle related to theft or infiltration. Bypassing locks and traps, pickpocketing and filching, covering your tracks, and other such activities all fall under the purview of this skill.","caa":"You can case a location with Burglary, to determine how hard it will be to break into and what kind of security you’re dealing with, as well as discover any vulnerabilities you might exploit. You can also examine the work of other burglars to determine how a particular heist was done, and create or discover aspects related to whatever evidence they may have left behind.","attack":"Burglary isn’t used for attacks.","defend":"Same here. It’s not really a conflict skill, so there’s not a lot of opportunity to use it to defend.","pc":true
         },

--- a/scripts/ManageSkills.js
+++ b/scripts/ManageSkills.js
@@ -1,5 +1,5 @@
 Hooks.once('init', async function () {
-    //On init, we initialise all settings and settings menus for dealing with skills 
+    //On init, we initialise all settings and settings menus for dealing with skills
     //We will be using this setting to store the world's list of skills.
     game.settings.register("ModularFate", "skills", {
         name: "Skill list",
@@ -101,32 +101,50 @@ Hooks.once('init', async function () {
                     if (game.user.isGM){
                         game.settings.set("ModularFate","skills",game.i18n.localize("ModularFate.FateCoreDefaultSkills"));
                         game.settings.set("ModularFate","defaultSkills","nothing");
+                        game.settings.set("ModularFate","skillsLabel",game.i18n.localize("ModularFate.defaultSkillsLabel"));
                     }
                 }
                 if (value=="clearAll"){
                     if (game.user.isGM) {
                         game.settings.set("ModularFate","skills",{});
+                        game.settings.set("ModularFate","skillsLabel",game.i18n.localize("ModularFate.defaultSkillsLabel"));
                     }
                 }
                 if (value=="fateCondensed"){
-                    if (game.user.isGM){ 
+                    if (game.user.isGM){
                         game.settings.set("ModularFate","skills",game.i18n.localize("ModularFate.FateCondensedDefaultSkills"));
                         game.settings.set("ModularFate","defaultSkills","nothing");
+                        game.settings.set("ModularFate","skillsLabel",game.i18n.localize("ModularFate.defaultSkillsLabel"));
                     }
                 }
                 if (value=="accelerated"){
                     if (game.user.isGM){
                         game.settings.set("ModularFate","skills",game.i18n.localize("ModularFate.FateAcceleratedDefaultSkills"));
                         game.settings.set("ModularFate","defaultSkills","nothing");
+                        game.settings.set("ModularFate","skillsLabel",game.i18n.localize("ModularFate.FateAcceleratedSkillsLabel"));
                     }
                 }
                 if (value=="dfa"){
                     if (game.user.isGM){
                         game.settings.set("ModularFate","skills",game.i18n.localize("ModularFate.DresdenFilesAcceleratedDefaultSkills"));
                         game.settings.set("ModularFate","defaultSkills","nothing");
+                        game.settings.set("ModularFate","skillsLabel",game.i18n.localize("ModularFate.FateAcceleratedSkillsLabel"));
                     }
                 }
             }
+    });
+
+    game.settings.register("ModularFate", "skillsLabel", {
+      name: game.i18n.localize("ModularFate.SkillsLabelName"),
+      hint: game.i18n.localize("ModularFate.SkillsLabelHint"),
+      scope: "world",     // This specifies a client-stored setting
+      config: true,        // This specifies that the setting appears in the configuration view
+      type: String,
+      restricted:true,
+      // I tried to set this to game.i18n.localize("ModularFate.defaultSkillsLabel")
+      // but that didn't work for me, so I put code in to check if it's empty,
+      // in the ModularFateCharacterSheet.getData() method.
+      default: "",
     });
 
     game.settings.register("ModularFate","stunts", {
@@ -140,7 +158,7 @@ Hooks.once('init', async function () {
 
     let skill_choices = {};
     let skills = game.settings.get("ModularFate", "skills")
-    
+
     skill_choices["None"]="None";
     skill_choices["Disable"]="Disable";
     for (let skill in skills){skill_choices[skill]=skill};
@@ -181,7 +199,7 @@ class SkillSetup extends FormApplication{
     static get defaultOptions() {
         const options = super.defaultOptions; //begin with the super's default options
         //The HTML file used to render this window
-        options.template = "systems/ModularFate/templates/SkillSetup.html"; 
+        options.template = "systems/ModularFate/templates/SkillSetup.html";
         options.width = "auto";
         options.height = "auto";
         options.title = `${game.i18n.localize("ModularFate.SetupSkillsTitle")} ${game.world.data.title}`;
@@ -198,7 +216,7 @@ class SkillSetup extends FormApplication{
         }
         return templateData;
     }
-    
+
       //Here are the action listeners
       activateListeners(html) {
         super.activateListeners(html);
@@ -220,7 +238,7 @@ class SkillSetup extends FormApplication{
         importSkills.on("click", event => this._onImportSkills(event, html));
         exportSkills.on("click", event => this._onExportSkills(event, html));
     }
-    
+
     //Here are the event listener functions.
 
     async _onExportSkill(event, html){
@@ -228,7 +246,7 @@ class SkillSetup extends FormApplication{
         let slb = html.find("select[id='skillListBox']")[0].value;
         let sk = skills[slb];
         let skill_text = `{"${slb}":${JSON.stringify(sk)}}`
- 
+
         new Dialog({
             title: game.i18n.localize("ModularFate.CopyAndPasteToSaveSkill"),
             content: `<div style="background-color:white; color:black;"><textarea rows="20" style="font-family:Montserrat; width:382px; background-color:white; border:1px solid lightsteelblue; color:black;">${skill_text}</textarea></div>`,
@@ -240,9 +258,9 @@ class SkillSetup extends FormApplication{
     async _onExportSkills(event, html){
         let skills = game.settings.get("ModularFate","skills");
         let skills_text = JSON.stringify(skills);
- 
+
         new Dialog({
-            title: game.i18n.localize("ModularFate.CopyAndPasteToSaveSkills"), 
+            title: game.i18n.localize("ModularFate.CopyAndPasteToSaveSkills"),
             content: `<div style="background-color:white; color:black;"><textarea rows="20" style="font-family:Montserrat; width:382px; background-color:white; border:1px solid lightsteelblue; color:black;">${skills_text}</textarea></div>`,
             buttons: {
             },
@@ -298,7 +316,7 @@ class SkillSetup extends FormApplication{
             //Code to delete the selected skill
             //First, get the name of the skill from the HTML element skillListBox
             let slb = html.find("select[id='skillListBox'")[0].value;
-            
+
             //Find that skill in the list of skills
             let skills=game.settings.get("ModularFate","skills");
             if (skills[slb] != undefined){
@@ -372,11 +390,11 @@ class EditSkill extends FormApplication{
                     existing = true;
                 }
             }
-            if (!existing){  
+            if (!existing){
                 if (this.skill.name != ""){
                     //That means the name has been changed. Delete the original aspect and replace it with this one.
                     delete skills[this.skill.name]
-                }                      
+                }
                 skills[name]=newSkill;
             }
             await game.settings.set("ModularFate","skills",skills);
@@ -388,16 +406,16 @@ class EditSkill extends FormApplication{
         const saveButton = html.find("button[id='edit_save_changes']");
         saveButton.on("click", event => this._onSaveButton(event, html));
     }
-        
+
     //Here are the event listener functions.
     async _onSaveButton(event,html){
         this.submit();
-    }    
+    }
 
     static get defaultOptions() {
         const options = super.defaultOptions;
-        options.template = "systems/ModularFate/templates/EditSkill.html"; 
-    
+        options.template = "systems/ModularFate/templates/EditSkill.html";
+
         //Define the FormApplication's options
         options.width = "1000";
         options.height = "auto";

--- a/scripts/ModularFateCharacter.js
+++ b/scripts/ModularFateCharacter.js
@@ -113,7 +113,7 @@ export class ModularFateCharacter extends ActorSheet {
             skill_name.on("click", event => this._onSkill_name(event, html));
             const sort = html.find("div[name='sort_player_skills'")
             sort.on("click", event => this._onSortButton(event, html));
-            
+
             const aspectButton = html.find("div[name='edit_player_aspects']");
             aspectButton.on("click", event => this._onAspectClick(event, html));
 
@@ -196,7 +196,7 @@ export class ModularFateCharacter extends ActorSheet {
                 let a = event.target.id.split("_")[0];
                 let aspect = this.actor.data.data.aspects[a];
                 let key = this.actor.id+aspect.name+"_aspect";
-        
+
                 if (game.user.expanded == undefined){
                     game.user.expanded = {};
                 }
@@ -215,7 +215,7 @@ export class ModularFateCharacter extends ActorSheet {
                 let t = event.target.id.split("_")[0];
                 let track = this.object.data.data.tracks[t];
                 let key = this.actor.id+track.name+"_track";
-            
+
                 if (game.user.expanded == undefined){
                     game.user.expanded = {};
                 }
@@ -349,7 +349,7 @@ export class ModularFateCharacter extends ActorSheet {
                 this.actor.items.forEach(item => {
                     let key = this.actor.id+item.id+"_extra";
                     game.user.expanded[key] = true;
-                })  
+                })
                 this.render(false);
             })
 
@@ -366,7 +366,7 @@ export class ModularFateCharacter extends ActorSheet {
             })
 
             input.on("focus", event => {
-                
+
                 if (this.editing == false) {
                     this.editing = true;
                 }
@@ -484,7 +484,7 @@ export class ModularFateCharacter extends ActorSheet {
             // Do nothing.
         }
     }
-    
+
     async _on_stunt_roll_click(event,html){
         let items = event.target.id.split("_");
         let name = items[0];
@@ -517,7 +517,7 @@ export class ModularFateCharacter extends ActorSheet {
 
         roll.toMessage({
             flavor: `<h1>${skill}</h1>${game.i18n.localize("ModularFate.RolledBy")}: ${game.user.name}<br>
-            ${game.i18n.localize("ModularFate.SkillRank")}: ${rank} (${rung})<br> 
+            ${game.i18n.localize("ModularFate.SkillRank")}: ${rank} (${rung})<br>
             ${game.i18n.localize("ModularFate.Stunt")}: ${name} (+${bonus})`,
             speaker: msg
         });
@@ -577,7 +577,7 @@ export class ModularFateCharacter extends ActorSheet {
         let e = new ExtraSheet(item);
         await e.render(true);
 
-    }    
+    }
 
     async _on_extras_delete(event, html){
         let del = await ModularFateConstants.confirmDeletion();
@@ -747,7 +747,7 @@ export class ModularFateCharacter extends ActorSheet {
         if (game.user.expanded[this.actor.id+"_biography"] == undefined) game.user.expanded[this.actor.id+"_biography"] = true;
         if (game.user.expanded[this.actor.id+"_description"] == undefined) game.user.expanded[this.actor.id+"_description"] = true;
         if (game.user.expanded[this.actor.id+"_extras"] == undefined) game.user.expanded[this.actor.id+"_extras"] = true;
-    
+
         // super.getData() now returns an object in this format:
         /*
             {
@@ -771,12 +771,12 @@ export class ModularFateCharacter extends ActorSheet {
 
         sheetData.paidTracks = 0;
         sheetData.paidStunts = 0;
-        sheetData.paidExtras = 0;   
+        sheetData.paidExtras = 0;
 
         sheetData.refreshSpent = 0; //Will increase when we count tracks with the Paid field and stunts.
         sheetData.freeStunts = game.settings.get("ModularFate", "freeStunts");
 
-        //Calculate cost of stunts here. Some cost more than 1 refresh, so stunts need a cost value        
+        //Calculate cost of stunts here. Some cost more than 1 refresh, so stunts need a cost value
         let tracks = sheetData.data.tracks; // Removed duplicate() here as we don't write to the tracks data, just read from it.
         for (let track in tracks) {
             if (tracks[track].paid) {
@@ -795,7 +795,7 @@ export class ModularFateCharacter extends ActorSheet {
         for (let s in stunts){
             sheetData.paidStunts += parseInt(stunts[s].refresh_cost);
         }
-        
+
         sheetData.paidStunts -= sheetData.freeStunts;
         sheetData.refreshSpent = sheetData.paidTracks + sheetData.paidStunts + sheetData.paidExtras;
 
@@ -815,7 +815,7 @@ export class ModularFateCharacter extends ActorSheet {
             if (checkSpent > worldRefresh) {
                 if (error) {
                     message += game.i18n.localize("ModularFate.AndSpentRefreshPlusRefreshGreaterThanGameRefresh")
-                } 
+                }
                 else {
                     message += game.i18n.localize("ModularFate.SpentRefreshPlusRefreshGreaterThanGameRefresh")
                     error = true;
@@ -844,9 +844,9 @@ export class ModularFateCharacter extends ActorSheet {
             if (ordered_skills[s].extra_tag != undefined){
                 let extra_id = ordered_skills[s].extra_tag.extra_id;
                 let extra = sheetData.items.find(item=>item.id == extra_id);
-        
+
                 if (extra != undefined && extra.data.data.countSkills){
-                    skillTotal += ordered_skills[s].rank;    
+                    skillTotal += ordered_skills[s].rank;
                 }
             }else {
                 skillTotal += ordered_skills[s].rank;
@@ -854,6 +854,9 @@ export class ModularFateCharacter extends ActorSheet {
         }
 
         sheetData.skillTotal = skillTotal;
+
+      let skills_label = game.settings.get("ModularFate", "skillsLabel");
+      sheetData.skillsLabel = skills_label || game.i18n.localize("ModularFate.defaultSkillsLabel");
         sheetData.ladder = ModularFateConstants.getFateLadder();
         sheetData.sortByRank = this.sortByRank;
         sheetData.gameSkillPoints = game.settings.get("ModularFate", "skillTotal")
@@ -867,7 +870,7 @@ export class ModularFateCharacter extends ActorSheet {
         }
         sheetData.track_categories=Array.from(cats);
         sheetData.category = this.track_category;
-    
+
         return sheetData;
     }
 }

--- a/templates/ModularFateSheet.html
+++ b/templates/ModularFateSheet.html
@@ -73,7 +73,7 @@
             <div class="mfate-sheet__column">
                 <div id="{{document.name}}_sheet_div" class="mfate-panel mfate-panel--skills">
                     <div class="mfate-panel__header">
-                        <div class="mfate-panel__header-label">{{localize 'ModularFate.Skills'}}</div>
+                        <div class="mfate-panel__header-label">{{ skillsLabel }}</div>
                         <!-- <button class="mfate-panel__header-button">Settings</button>
                             <button class="mfate-panel__header-button">Sort</button> -->
                         <div name="sort_player_skills" i icon class="fas fa-sort mfate-panel__header-button" title="{{localize 'ModularFate.SwitchSort'}}"></div>
@@ -121,7 +121,7 @@
                                 <div title="{{localize 'ModularFate.OpenTheTrackEditor'}}" style="font-size:medium;" name="edit_player_tracks" i icon class="fas fa-cog mfate-panel__header-button"></div>
                             </div>
                             <div name="tracks_body" id="tracks_body" style="scrollbar-width:thin">
-                                {{#each data.tracks}}{{#if this.enabled}}{{#if (category ../category this.category)}} 
+                                {{#each data.tracks}}{{#if this.enabled}}{{#if (category ../category this.category)}}
                                 <div class="mfate-tracks__list">
                                     <div class="mfate-tracks__item">
                                         <div class="mfate-tracks__item-label">
@@ -166,7 +166,7 @@
                                     </div>
                                 </div>
                                 {{#if (expanded ../this.document (concat this.name '_track'))}}<div class="mfate_aspects-list__label">{{this.name}} {{localize 'ModularFate.Notes'}}:</div><textarea class="cs_box mfate-tracks-notes__input" type="text" name="data.tracks.{{this.name}}.notes">{{this.notes}}</textarea>{{/if}}
-                                {{/if}}{{/if}}                                
+                                {{/if}}{{/if}}
                                 {{/each}}
                             <!--end of tracks body-->
                             </div>
@@ -218,7 +218,7 @@
                                             <button type="button" name="expandStunt" style="width:20px; height:20px; float:left; background-color:transparent; border:none" {{#if (expanded ../this.document (concat this.name '_stunt'))}}icon class="fas fa-compress fu_button" title="{{localize 'ModularFate.Minimise'}}"{{else}}icon class = "fas fa-expand fu_button" title="{{localize 'ModularFate.Maximise'}}"{{/if}} id="{{this.name}}_expandStunt"></button>
                                             <i style="font-style:normal; padding-left:5px">{{this.name}} ({{this.linked_skill}})</i>
                                             {{#if (eq this.extra_tag undefined)}}
-                                            <button type="button" i icon class="fas fa-trash mfate-stunts__row-header-icon fu_button" name="delete_stunt" id="{{this.name}}_delete"></button> 
+                                            <button type="button" i icon class="fas fa-trash mfate-stunts__row-header-icon fu_button" name="delete_stunt" id="{{this.name}}_delete"></button>
                                             {{/if}}
                                             {{#if (eq this.linked_skill (localize 'ModularFate.none'))}}{{else}}
                                             <button type="button" name="stunt_name" id="{{this.name}}_{{this.linked_skill}}_{{this.bonus}}" i icon class="fas fa-dice mfate-stunts__row-header-icon fu_button"></button>
@@ -266,7 +266,7 @@
 
             </div>
             <div {{#if (expanded this.document '_biography')}}class="mfate-biography"{{else}}class="mfate-biography-collapsed"{{/if}}>
-                <div class="mfate-panel__header">                        
+                <div class="mfate-panel__header">
                         <div {{#if (expanded this.document '_biography')}}class="i icon fas fa-compress mfate-panel__header-button" title="{{localize 'ModularFate.Minimise'}}" {{else}}title="{{localize 'ModularFate.Maximise'}}" class="i icon fas fa-expand mfate-panel__header-button"{{/if}} name="expandBiography" title="{{localize 'ModularFate.Maximise'}}"></div>
                     <div class="mfate-panel__header-label">{{localize 'ModularFate.Biography'}}</div>
                 </div>
@@ -278,7 +278,7 @@
                         <div {{#if (expanded this.document '_extras')}}class="i icon fas fa-compress mfate-panel__header-button" title="{{localize 'ModularFate.Minimise'}}" {{else}}title="{{localize 'ModularFate.Maximise'}}" class="i icon fas fa-expand mfate-panel__header-button"{{/if}} name="expandExtrasPane" title="{{localize 'ModularFate.Maximise'}}"></div>{{localize 'ModularFate.Extras'}}
                         {{#if (expanded this.document '_extras')}}<div title="{{localize 'ModularFate.AddANewExtra'}}" style="font-size:medium; padding-top:5px; padding-left:5px; padding-right:5px; padding-bottom:5px; float:right;" name="add_player_extra" i icon class="fas fa-plus mfate-panel__header-button"></div>{{/if}}
                         {{#if (expanded this.document '_extras')}}<div class="i icon fas fa-expand mfate-panel__header-button" style="font-size:medium; padding-top:5px; padding-left:5px; padding-right:5px; padding-bottom:5px; float:right;" name="expandExtras" title="{{localize 'ModularFate.MaximiseAll'}}"></div>{{/if}}
-                        {{#if (expanded this.document '_extras')}}<div class="i icon fas fa-compress mfate-panel__header-button" style="font-size:medium; padding-top:5px; padding-left:5px; padding-right:5px; padding-bottom:5px; float:right;" name="compressExtras" title="{{localize 'ModularFate.MinimiseAll'}}"></div>{{/if}}                        
+                        {{#if (expanded this.document '_extras')}}<div class="i icon fas fa-compress mfate-panel__header-button" style="font-size:medium; padding-top:5px; padding-left:5px; padding-right:5px; padding-bottom:5px; float:right;" name="compressExtras" title="{{localize 'ModularFate.MinimiseAll'}}"></div>{{/if}}
                     </div>
                 </div>
                 {{#if (expanded this.document '_extras')}}


### PR DESCRIPTION
I wasn't able to get the default value of the setting to use the localized value, so I set it as the empty string, and tested that in the `ModularFateCharacter.getData()` method to implement the default.

This isn't the best user experience and I would like to see what I was doing wrong there, or if this is a limitation of the system.  Perhaps it's an order of operations thing, although the `game.i18n.localize()` method works on the other properties passed into the `game.settings.register()` method.

I used the setting directly in the `.getData()` method rather than having it stored as a property in the actor data, let me know if that is something you would like to have stored on the actor.  I can see advantages in doing this either way.

Also, I feel like a better place to put this setting would be on the "Setup Skills" dialog/form, but wanted to get something implemented quickly and this seemed the easiest.

Also, apologies for the whitespace changes.  I can get those cleaned up later today. (I will probably amend the commits for that.)

